### PR TITLE
Fix: incorrect patched_bytes construction in wildcard_replace

### DIFF
--- a/_utils.py
+++ b/_utils.py
@@ -256,9 +256,9 @@ def wildcard_replace(data: bytes, pattern: str | list, replace: str | list):
     for p, r in zip(pattern, replace):
         if p == "??":
             regex_bytes += b"(.)"
-            patched_bytes += b"(.)"
             if r == "??":
                 repl_bytes += b"\\" + str(group_count).encode()
+                patched_bytes += b"(.)"
             else:
                 repl_bytes += bytes.fromhex(r)
                 patched_bytes += re.escape(bytes.fromhex(r))


### PR DESCRIPTION
修复了 wildcard_replace 方法中的一个匹配构造错误问题：
当 pattern 中某位置为通配符 "??"，而 replace 中对应位置为具体字节时，原逻辑错误地为 patched_bytes 添加了捕获组占位符，导致生成的 patched_bytes 结构不正确，从而造成 patched_matches 匹配失败。

问题复现示例:
```python
data_hex_str = "00 00 00 E8 30 30 30 30 89 C6 48 85 FF 74 1D F0 FF 4F 00 00 00 8B B5 20 04 00 00 81 C6 12 27 00 00 F0 FF 4F 00 00 00"
data = bytes.fromhex(data_hex_str.strip())

pattern = "E8 ?? ?? ?? ?? 89 C6 48 85 FF 74 1D F0 FF 4F"
replace = "8B B5 20 04 00 00 81 C6 12 27 00 00 ?? ?? ??"
```