### PR TITLE
Fix: resolve regex group reference ambiguity using \\g<> syntax

### DIFF
--- a/_utils.py
+++ b/_utils.py
@@ -257,7 +257,7 @@ def wildcard_replace(data: bytes, pattern: str | list, replace: str | list):
         if p == "??":
             regex_bytes += b"(.)"
             if r == "??":
-                repl_bytes += b"\\" + str(group_count).encode()
+                repl_bytes += f"\\g<{group_count}>".encode()
                 patched_bytes += b"(.)"
             else:
                 repl_bytes += bytes.fromhex(r)


### PR DESCRIPTION
# Fix: resolve regex group reference ambiguity using \\g<> syntax

```python
# repl_bytes += b"\\" + str(group_count).encode()
# 当原引用组形式"\\(\d+)"后跟数字时, 可能导致引用歧义, 导致拼接错误, 可优化为用"\g<数字>"替代.
repl_bytes += f"\\g<{group_count}>".encode()
```

## 示例数据源(取自4.1.2.11 Weixin的 Weixin.dll)
```
... 84 C0 75 1b e8 d6 60 f8 ff 84 c0 75 12 e8 ed 74 05 00 48 89 c1 48 89 f2 e8 a2 81 05 00 31 ff 89 f8 48 83 c4 28 5f 5e c3 cc cc cc cc CC CC ...
```

## 特征码
```json
"original": "75 1B E8 ?? ?? ?? ?? 84 C0 75 12 E8 ?? ?? ?? ?? 48 89 C1 48 89 F2 E8 ?? ?? ?? ?? 31 FF 89 F8 48 83 C4 28 5F 5E C3 CC CC CC CC",
"modified": "EB ..."
```

## 输出
```bash
构建匹配模式：
original_regex_bytes: b'u\x1b\xe8(.)(.)(.)(.)\x84\xc0u\x12\xe8(.)(.)(.)(.)H\x89\xc1H\x89\xf2\xe8(.)(.)(.)(.)1\xff\x89\xf8H\x83\xc4\\(_\\^\xc3\xcc\xcc\xcc\xcc'
modified_regex_bytes: b'\xeb\x1b\xe8(.)(.)(.)(.)\x84\xc0u\x12\xe8(.)(.)(.)(.)H\x89\xc1H\x89\xf2\xe8(.)(.)(.)(.)1\xff\x89\xf8H\x83\xc4\\(_\\^\xc3\xcc\xcc\xcc\xcc'
repl_bytes: b'\xeb\x1b\xe8\\1\\2\\3\\4\x84\xc0u\x12\xe8\\5\\6\\7\\8H\x89\xc1H\x89\xf2\xe8\\9\\10\\11\\121\xff\x89\xf8H\x83\xc4(_^\xc3\xcc\xcc\xcc\xcc'
识别到：
Original: 75 1b e8 d6 60 f8 ff 84 c0 75 12 e8 ed 74 05 00 48 89 c1 48 89 f2 e8 a2 81 05 ̲0̲0 ̲3̲1 ff 89 f8 48 83 c4 28 5f 5e c3 cc cc cc cc
Modified: eb 1b e8 d6 60 f8 ff 84 c0 75 12 e8 ed 74 05 00 48 89 c1 48 89 f2 e8 a2 81 05 ̲5̲1 ff 89 f8 48 83 c4 28 5f 5e c3 cc cc cc cc
```
第十二处(.), 即在替换模式中\\12, 由于后面是1, 导致歧义, 将00 31给转成51了.